### PR TITLE
mode choice with 60% telecommute rate

### DIFF
--- a/demos_urbansim/configs/calibrated_configs/custom/06197001/mode_choice/mode_choice_logsum.yaml
+++ b/demos_urbansim/configs/calibrated_configs/custom/06197001/mode_choice/mode_choice_logsum.yaml
@@ -16,7 +16,7 @@ saved_object:
     sh3_ASC: -1.7508423328399658
     short_bike: -1.3757458448559552
     short_walk: -1.8236679024083855
-    telecommute_ASC: -5.813110828399658
+    telecommute_ASC: -3.791193962097168
     tnc_ASC: -5.344948768615723
     train_ASC: -5.423836708068848
     walk_ASC: 3.798496723175049


### PR DESCRIPTION
The mode choice specification changes so that the telecommute rate is 60%. This change is temporary to test telecommute sensitivities when running UrbanSim + DEMOS + MLCM together in PILATES. 