### PR TITLE
Long-run scenario changes for LBNL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
 RUN pip install -r requirements.txt
 
 WORKDIR /base/demos_urbansim
-ENTRYPOINT ["python", "-u", "simulate.py", "-c", "-cf", "custom", "-l", "-sg"]
+ENTRYPOINT ["python", "-u", "simulate.py", "-c", "-cf", "custom", "-l"]

--- a/demos_urbansim/configs/calibrated_configs/custom/06197001/mode_choice/mode_choice_logsum.yaml
+++ b/demos_urbansim/configs/calibrated_configs/custom/06197001/mode_choice/mode_choice_logsum.yaml
@@ -16,7 +16,7 @@ saved_object:
     sh3_ASC: -1.7508423328399658
     short_bike: -1.3757458448559552
     short_walk: -1.8236679024083855
-    telecommute_ASC: -4.556661128997803
+    telecommute_ASC: -5.813110828399658
     tnc_ASC: -5.344948768615723
     train_ASC: -5.423836708068848
     walk_ASC: 3.798496723175049

--- a/demos_urbansim/models.py
+++ b/demos_urbansim/models.py
@@ -3829,7 +3829,7 @@ def update_linked_table(tbl, col_name, added, copied, removed):
 
 @orca.step('households_relocation_basic')
 def households_relocation_basic(households):
-    return simple_relocation(households, .034, "block_id")
+    return simple_relocation(households, .005, "block_id")
 
 
 def simple_relocation(choosers, relocation_rate, fieldname):


### PR DESCRIPTION
## Describe your changes
1. Revert the relocation rate to the default value (0.5%) to be consistent with previous runs. 
2. Baseline telecommute rate of 6.5% 
3. Remove the `-sg` flag from the docker entry point to avoid running the segmented model. 